### PR TITLE
[fix]認証機能 sign_up時のエラーメッセージなど

### DIFF
--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -1,0 +1,31 @@
+module DeviseHelper
+  def resource_name
+    :user
+  end
+
+  def resource
+    @resource ||= User.new
+  end
+
+  def devise_mapping
+    @devise_mapping ||= Devise.mappings[:user]
+  end
+
+  def devise_error_messages!
+    return "" if resource.errors.empty?
+
+    html = ""
+    messages = resource.errors.full_messages.each do |errmsg|
+      html += <<-EOF
+      <div class="alert alert-danger alert-dismissible" role="alert">
+        <button type="button" class="close" data-dismiss="alert">
+          <span aria-hidden="true">&times;</span>
+          <span class="sr-only">close</span>
+        </button>
+        #{errmsg}
+      </div>
+      EOF
+    end
+    html.html_safe
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,5 +3,4 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
-  validates :email,:presence => {:message => "XXXXXXX."}
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -25,6 +25,6 @@
   </div>
 </div>
 
-<p><%= t('.unhappy', :default => 'Unhappy') %><%= link_to t('.cancel_my_account', :default => "Cancel my account"), registration_path(resource_name), :data => { :confirm => t('.are_you_sure', :default => "Are you sure?") }, :method => :delete %>.</p>
+<p><%= link_to t('.cancel_my_account', :default => "Cancel my account"), registration_path(resource_name), :data => { :confirm => t('.are_you_sure', :default => "Are you sure?") }, :method => :delete %>.</p>
 
 <%= link_to t('.back', :default => 'Back'), :back %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,7 +55,7 @@
             <br>
             <!-- user_signed_in? はユーザがログインしているか調べるdeviseのHelperメソッド -->
             <% if user_signed_in? %> 
-              Logged in as <strong><%= current_user.email %></strong>.
+              <strong><%= current_user.email %></strong>.
               <li><%= link_to 'プロフィール変更', edit_user_registration_path %></li>
               <li><%= link_to "ログアウト", destroy_user_session_path, method: :delete %></li>
             <% else %>
@@ -81,6 +81,7 @@
           <% if alert %>
             <p class="alert alert-danger"><%= alert %></p>
           <% end %>
+          <%= devise_error_messages! %>
           <!-- end devise setting-->
 
           <%= yield %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -32,7 +32,7 @@
         <td><%= user.last_sign_in_at %></td>
         <td><%= user.current_sign_in_ip %></td>
         <td><%= user.last_sign_in_ip %></td>
-        <td><%=l user.created_at %></td>
+        <td><%= user.created_at %></td>
         <td>
           <%= link_to t('.edit', :default => t("helpers.links.edit")),
                       edit_user_path(user), :class => 'btn btn-default btn-xs' %>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -17,13 +17,6 @@ ja:
         too_long: "は%{count}文字以下に設定して下さい。"
         invalid: "は有効でありません。"
         confirmation: "が内容とあっていません。"
-      models:
-        user:
-          attributes:
-            email:
-              taken: "the email address %{value} has already been registered"
-            password:
-              too_short: "the password is too short (minimum %{count} characters)"
   devise:
     confirmations:
       new:


### PR DESCRIPTION
- アカウント登録時もエラーメッセージを表示する
- 登録時エラーメッセージ精査
- unhappy気に入らない？を削除
- ヘッダーのlogged in as を削除
